### PR TITLE
New zero_out_[all,diags] methods. Minor improvements.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Björn Dahlgren
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/include/block_diag_ilu.hpp
+++ b/include/block_diag_ilu.hpp
@@ -4,12 +4,19 @@
 #include <utility>
 #include <memory>
 #include <cmath> // std::abs
-// C++11 source code
+
+// block_diag_ilu
+// ==============
+// Algorithm: Incomplete LU factorization of block diagonal matrices with weak sub-/super-diagonals
+// Language: C++11
+// License: Open Source, see LICENSE.txt (BSD 2-Clause license)
+// Author: Björn Dahlgren 2015
+// URL: https://github.com/chemreac/block_diag_ilu
 
 
 namespace block_diag_ilu {
 
-    // make_unique<int[]>() only in C++14, work around:
+    // make_unique<T[]>() only in C++14, work around:
     // begin copy paste from http://stackoverflow.com/a/10150181/790973
     template <class T, class ...Args>
     typename std::enable_if
@@ -36,7 +43,7 @@ namespace block_diag_ilu {
     // end copy paste from http://stackoverflow.com/a/10150181/790973
 
 #if defined(WITH_BLOCK_DIAG_ILU_DGETRF)
-    int dgetrf_square(const int dim, double * const __restrict__ a,
+    inline int dgetrf_square(const int dim, double * const __restrict__ a,
                       const int lda, int * const __restrict__ ipiv);
 #else
     extern "C" void dgetrf_(const int* dim1, const int* dim2, double* a, int* lda, int* ipiv, int* info);
@@ -104,29 +111,33 @@ namespace block_diag_ilu {
             double * const __restrict__ sub_data,
             const double * const __restrict__ sup_data,
             int nblocks, 
-            int blockw, int ndiag, int ld_block_data=0)
+            int blockw, int ndiag,
+            int ld_block_data=0)
             // block_data : column major ordering (Fortran style), 
             //     (will be overwritten)
             // sub_data : sub[0], sub[1], ... sup[ndiag-1]
             // sup_data : sup[0], sup[1], ... sup[ndiag-1]
+            // use ld_block_data to avoid false sharing in parallelized
+            // execution (TODO: guard against false sharing in diagdata..)
             : block_data(block_data), sub_data(sub_data), sup_data(sup_data),
               nblocks(nblocks), blockw(blockw), ndiag(ndiag), 
               ld_block_data((ld_block_data) ? ld_block_data : blockw),
               piv(make_unique<int[]>(blockw*nblocks)),
               rowbycol(make_unique<int[]>(blockw*nblocks)),
               colbyrow(make_unique<int[]>(blockw*nblocks)) {
-            int info = 0; // currently ignored
+            int info_ = 0;
 #if defined(WITH_BLOCK_DIAG_ILU_OPENMP)
 #pragma omp parallel for
 #endif
             for (int bi=0; bi<nblocks; ++bi){
 #if defined(WITH_BLOCK_DIAG_ILU_DGETRF)
-                info = dgetrf_square(
+                int info = dgetrf_square(
                            this->blockw,
                            &block_data[bi*blockw*(this->ld_block_data)],
                            this->ld_block_data,
                            &(this->piv[bi*blockw]));
 #else
+                int info;
                 dgetrf_(&(this->blockw),
                         &(this->blockw),
                         &block_data[bi*blockw*(this->ld_block_data)],
@@ -134,6 +145,8 @@ namespace block_diag_ilu {
                         &(this->piv[bi*blockw]),
                         &info);
 #endif
+                if ((info != 0) && (info_ == 0))
+                    info_ = info;
                 for (int ci = 0; ci < blockw; ++ci){
                     for (int di = 0; (di < (this->ndiag)) && (bi+di < (this->nblocks) - 1); ++di){
                         const int skip_ahead = diag_store_len(this->nblocks, this->blockw, di);
@@ -144,11 +157,13 @@ namespace block_diag_ilu {
                 rowpiv2rowbycol(blockw, &piv[bi*blockw], &rowbycol[bi*blockw]);
                 rowbycol2colbyrow(blockw, &rowbycol[bi*blockw], &colbyrow[bi*blockw]);
             }
+            if (info_)
+                throw std::runtime_error("ILU failed!");
         }
         void solve(const double * const __restrict__ b, double * const __restrict__ x) const {
             // before calling solve: make sure that the 
             // block_data and sup_data pointers are still valid.
-            std::unique_ptr<double[]> y (new double[(this->nblocks)*(this->blockw)]);
+            auto y = make_unique<double[]>((this->nblocks)*(this->blockw));
             for (int bri = 0; bri < (this->nblocks); ++bri){
                 for (int li = 0; li < (this->blockw); ++li){
                     double s = 0.0;
@@ -186,22 +201,53 @@ namespace block_diag_ilu {
     class BlockDiagMat {
     public:
         const int nblocks, blockw, ndiag, sub_offset, sup_offset;
+        const std::size_t data_len;
         std::unique_ptr<double[]> data;
         BlockDiagMat(int nblocks, int blockw, int ndiag) :
             nblocks(nblocks), blockw(blockw), ndiag(ndiag),
             sub_offset(nblocks*blockw*blockw),
             sup_offset(nblocks*blockw*blockw + diag_store_len(nblocks, blockw, ndiag)),
-            data(make_unique<double[]>(nblocks*blockw*blockw+2*diag_store_len(nblocks, blockw, ndiag)))
+            data_len(nblocks*blockw*blockw+2*diag_store_len(nblocks, blockw, ndiag)),
+            data(make_unique<double[]>(data_len))
             {}
-        inline double& block(int bi, int ri, int ci) {
+        inline void zero_out_all() noexcept {
+            for (std::size_t i=0; i<(this->data_len); ++i){
+                this->data[i] = 0.0;
+            }
+        }
+        inline void zero_out_diags() noexcept {
+            for (std::size_t i=(this->sub_offset); i<(this->data_len); ++i){
+                this->data[i] = 0.0;
+            }
+        }
+        inline double& block(int bi, int ri, int ci) noexcept {
             return data[bi*(this->blockw)*(this->blockw) + ci*(this->blockw) + ri];
         }
-        inline double& sub(int di, int bi, int lci) {
+        inline double& sub(int di, int bi, int lci) noexcept {
             return data[this->sub_offset + diag_store_len(this->nblocks, this->blockw, di) + bi*(this->blockw) + lci];
         }
-        inline double& sup(int di, int bi, int lci) {
+        inline double& sup(int di, int bi, int lci) noexcept {
             return data[this->sup_offset + diag_store_len(this->nblocks, this->blockw, di) + bi*(this->blockw) + lci];
         }
+
+#ifdef UNIT_TEST
+        double get(int ri, int ci) {
+            const int bri = ri / this->blockw;
+            const int bci = ci / this->blockw;
+            const int lri = ri - bri*this->blockw;
+            const int lci = ci - bci*this->blockw;
+            if (bri == bci)
+                return this->block(bri, lri, lci);
+            if (std::abs(bri - bci) > ndiag)
+                return 0.0;
+            if (lri != lci)
+                return 0.0;
+            if (bri - bci > 0)
+                return this->sub(bri-bci-1, bci, lci);
+            return this->sup(bci-bri-1, bri, lri);
+        }
+#endif
+
         void set_to_1_minus_gamma_times_other(double gamma, BlockDiagMat &other) {
             // Scale main blocks by -gamma
             for (int bi=0; bi<this->nblocks; ++bi)
@@ -231,14 +277,15 @@ namespace block_diag_ilu {
                        this->nblocks, this->blockw, this->ndiag);
         }
         void dot_vec(const double * const vec, double * const out){
+            // out need not be zeroed out before call
             const int nblocks = this->nblocks;
             const int blockw = this->blockw;
             for (int i=0; i<nblocks*blockw; ++i)
                 out[i] = 0.0;
-            for (int bi=0; bi<nblocks; ++bi)
-                for (int ci=0; ci<blockw; ++ci)
-                    for (int ri=0; ri<blockw; ++ri)
-                        out[bi*blockw + ri] += vec[bi*blockw + ci]*(this->block(bi, ri, ci));
+            for (int bri=0; bri<nblocks; ++bri)
+                for (int lci=0; lci<blockw; ++lci)
+                    for (int lri=0; lri<blockw; ++lri)
+                        out[bri*blockw + lri] += vec[bri*blockw + lci]*(this->block(bri, lri, lci));
             for (int di=0; di<this->ndiag; ++di)
                 for (int bi=0; bi<nblocks-di-1; ++bi)
                     for (int ci=0; ci<blockw; ++ci){
@@ -251,15 +298,15 @@ namespace block_diag_ilu {
 }
 
 #if defined(WITH_BLOCK_DIAG_ILU_DGETRF)
-using std::abs;
-int block_diag_ilu::dgetrf_square(const int dim, double * const __restrict__ a,
-                                  const int lda, int * const __restrict__ ipiv){
+inline int block_diag_ilu::dgetrf_square(const int dim, double * const __restrict__ a,
+                                         const int lda, int * const __restrict__ ipiv){
     // Unblocked algorithm for LU decomposition of square matrices
-    // using Doolittle's algorithm with rowswaps.
+    // employing Doolittle's algorithm with rowswaps.
     //
     // ipiv indexing starts at 1 (Fortran compability)
     if (dim == 0) return 0;
 
+    int info = 0;
     auto A = [&](int ri, int ci) -> double& { return a[ci*lda + ri]; };
     auto swaprows = [&](int ri1, int ri2) { // this is not cache friendly
         for (int ci=0; ci<dim; ++ci){
@@ -271,20 +318,22 @@ int block_diag_ilu::dgetrf_square(const int dim, double * const __restrict__ a,
 
     for (int i=0; i<dim-1; ++i) {
         int pivrow = i;
-        double absmax = abs(A(i, i));
+        double absmax = std::abs(A(i, i));
         for (int j=i; j<dim; ++j) {
             // Find pivot
-            double curabs = abs(A(j, i));
+            double curabs = std::abs(A(j, i));
             if (curabs > absmax){
                 absmax = curabs;
                 pivrow = j;
             }
         }
+        if ((absmax == 0) && (info == 0))
+            info = pivrow+1;
+        ipiv[i] = pivrow+1;
         if (pivrow != i) {
             // Swap rows
             swaprows(i, pivrow);
         }
-        ipiv[i] = pivrow+1;
         // Eliminate in column
         for (int ri=i+1; ri<dim; ++ri){
             A(ri, i) = A(ri, i)/A(i, i);
@@ -297,6 +346,7 @@ int block_diag_ilu::dgetrf_square(const int dim, double * const __restrict__ a,
         }
     }
     ipiv[dim-1] = dim;
+    return info;
 }
 #endif
 

--- a/tests/test_block_diag_ilu.cpp
+++ b/tests/test_block_diag_ilu.cpp
@@ -341,3 +341,33 @@ TEST_CASE( "dot_vec", "[BlockDiagMat]" ) {
     REQUIRE( abs(b[4] - bref[4]) < 1e-15 );
     REQUIRE( abs(b[5] - bref[5]) < 1e-15 );
 }
+
+TEST_CASE( "dot_vec2", "[BlockDiagMat]" ) {
+    const int blockw = 4;
+    const int nblocks = 3;
+    const int nx = blockw*nblocks;
+    const int ndiag = 2;
+    const int ndata = blockw*blockw*nblocks + \
+        2*block_diag_ilu::diag_store_len(nblocks, blockw, ndiag);
+
+    block_diag_ilu::BlockDiagMat bdm {nblocks, blockw, ndiag};
+    for (int i=0; i<ndata; ++i)
+        bdm.data[i] = i + 2.5;
+
+    std::array<double, nx> x;
+    for (int i=0; i<nx; ++i)
+        x[i] = 1.5*nblocks*blockw - 2.5*i;
+
+    std::array<double, nblocks*blockw> bref;
+    for (int i=0; i<nx; ++i){
+        double val = 0.0;
+        for (int j=0; j<nx; ++j){
+            val += x[j] * bdm.get(i, j);
+        }
+        bref[i] = val;
+    }
+    std::array<double, nblocks*blockw> b;
+    bdm.dot_vec(x.data(), b.data());
+    for (int i=0; i<nx; ++i)
+        REQUIRE( abs(b[i] - bref[i]) < 1e-15 );
+}


### PR DESCRIPTION
- Added	zero_out_all() and zero_out_diags() methods
- Made dgetrf_square inline (one definition rule)
- Added License text
- Added	data_len member	variable
- Throw runtime error when LU decomposition fails